### PR TITLE
Fix archiveFiles - en-dash instead of hyphen

### DIFF
--- a/src/DLConversion.ps1
+++ b/src/DLConversion.ps1
@@ -2371,7 +2371,7 @@ Function archiveFiles
 	{
 		Try 
 		{
-			rename-item –path $script:sLogPath –newname $script:archiveXMLPath
+			rename-item -path $script:sLogPath -newname $script:archiveXMLPath
 		}
 		Catch 
 		{


### PR DESCRIPTION
The funciton which renames the Working folder at the end of the script process was broken. The script accidentally contained en-dashes (–) instead of hyphens (-) causing issues when it was downloaded.