### PR TITLE
Change to handle distribution lists with periods in their name

### DIFF
--- a/src/DLConversion.ps1
+++ b/src/DLConversion.ps1
@@ -5192,9 +5192,9 @@ Function createAndUpdateMailOnMicrosoftAddress
 
 		$functionContactRemoteAddress = $functionContactRemoteAddress -split "@"
 
-		$functionContactRemoteAddress = $functionContactRemoteAddress -split "\."
+		$functionContactRemoteAddressDomain = $functionContactRemoteAddress[1] -split "\."
 
-		$script:remoteRoutingAddress = $functionContactRemoteAddress[0] + "@" + $functionContactRemoteAddress[1] + ".mail." + $functionContactRemoteAddress[2] + "." + $functionContactRemoteAddress[3]
+		$script:remoteRoutingAddress = $functionContactRemoteAddress[0] + "@" + $functionContactRemoteAddressDomain[0] + ".mail." + $functionContactRemoteAddressDomain[1] + "." + $functionContactRemoteAddressDomain[2]
 
 		$script:remoteRoutingAddress = $script:remoteRoutingAddress.ToLower()
 	}


### PR DESCRIPTION
At present the script cannot cope with distribution lists which have a period (.) before the domain name

This change should fix that.